### PR TITLE
Fallback to C++ implementation if rust frontend return unimplemented error (fixes #6)

### DIFF
--- a/js/src/frontend-rs/frontend-rs.h
+++ b/js/src/frontend-rs/frontend-rs.h
@@ -13,6 +13,7 @@ struct CVec {
 struct JsparagusResult {
   CVec<uint8_t> bytecode;
   CVec<CVec<uint8_t>> strings;
+  bool unimplemented;
 };
 
 extern "C" {

--- a/js/src/frontend/Frontend2.h
+++ b/js/src/frontend/Frontend2.h
@@ -17,6 +17,7 @@
 
 bool InitScript(JSContext* cx, JS::HandleScript script,
                 JS::HandleFunction functionProto);
-bool Create(JSContext* cx, const uint8_t* bytes, size_t length);
+bool Create(JSContext* cx, const uint8_t* bytes, size_t length,
+            bool* unimplemented);
 
 #endif /* frontend_Frontend2_h */

--- a/js/src/shell/js.cpp
+++ b/js/src/shell/js.cpp
@@ -1434,12 +1434,20 @@ static MOZ_MUST_USE bool ReadEvalPrintLoop(JSContext* cx, FILE* in,
       break;
     }
 
+    bool unimplemented = false;
     if (rustFrontend) {
       AutoReportException are(cx);
-      if (!Create(cx, (const uint8_t*)buffer.begin(), buffer.length())) {
+      if (!Create(cx, (const uint8_t*)buffer.begin(), buffer.length(),
+                  &unimplemented)) {
         return false;
       }
-    } else {
+
+      if (unimplemented) {
+        fprintf(stderr, "Falling back!\n");
+      }
+    }
+
+    if (!rustFrontend || unimplemented) {
       // Report exceptions but keep going.
       AutoReportException are(cx);
       mozilla::Unused << EvalUtf8AndPrint(cx, buffer.begin(), buffer.length(),


### PR DESCRIPTION
Reflected the API change in https://github.com/jorendorff/jsparagus/pull/33

Added `JsparagusResult.unimplemented` field to report the unimplemented error from Rust part to C++ part.
`Create` function returns `unimplemented` flag by out-parameter, and the consumer in JS shell fallbacks to C++ implementation on the error.
