### PR TITLE
Integrate Jsparagus into CompileGlobalScript (fixes #8)

### DIFF
--- a/js/public/ContextOptions.h
+++ b/js/public/ContextOptions.h
@@ -37,7 +37,8 @@ class JS_PUBLIC_API ContextOptions {
         dumpStackOnDebuggeeWouldRun_(false),
         werror_(false),
         strictMode_(false),
-        extraWarnings_(false)
+        extraWarnings_(false),
+        tryRustFrontend_(false)
 #ifdef FUZZING
         ,
         fuzzing_(false)
@@ -173,6 +174,14 @@ class JS_PUBLIC_API ContextOptions {
     return *this;
   }
 
+  // Try compiling Rust frontend first, and fallback to C++ implementation when
+  // it fails.
+  bool tryRustFrontend() const { return tryRustFrontend_; }
+  ContextOptions& setTryRustFrontend(bool flag) {
+    tryRustFrontend_ = flag;
+    return *this;
+  }
+
 #ifdef FUZZING
   bool fuzzing() const { return fuzzing_; }
   ContextOptions& setFuzzing(bool flag) {
@@ -212,6 +221,7 @@ class JS_PUBLIC_API ContextOptions {
   bool werror_ : 1;
   bool strictMode_ : 1;
   bool extraWarnings_ : 1;
+  bool tryRustFrontend_ : 1;
 #ifdef FUZZING
   bool fuzzing_ : 1;
 #endif

--- a/js/src/frontend/BytecodeCompilation.h
+++ b/js/src/frontend/BytecodeCompilation.h
@@ -78,6 +78,8 @@ class MOZ_STACK_CLASS BytecodeCompiler {
  public:
   JSContext* context() const { return cx; }
 
+  const JS::ReadOnlyCompileOptions& getOptions() const { return options; };
+
   ScriptSourceObject* sourceObjectPtr() const { return sourceObject.get(); }
 
  protected:

--- a/js/src/frontend/BytecodeCompiler.cpp
+++ b/js/src/frontend/BytecodeCompiler.cpp
@@ -20,6 +20,7 @@
 #include "frontend/EitherParser.h"
 #include "frontend/ErrorReporter.h"
 #include "frontend/FoldConstants.h"
+#include "frontend/Frontend2.h"  // Jsparagus
 #include "frontend/ModuleSharedContext.h"
 #include "frontend/Parser.h"
 #include "js/SourceText.h"
@@ -227,6 +228,17 @@ JSScript* frontend::CompileGlobalScript(
 JSScript* frontend::CompileGlobalScript(
     GlobalScriptInfo& info, JS::SourceText<Utf8Unit>& srcBuf,
     ScriptSourceObject** sourceObjectOut /* = nullptr */) {
+  if (info.context()->options().tryRustFrontend()) {
+    bool unimplemented = false;
+    auto script = Jsparagus::compileGlobalScript(info, srcBuf, sourceObjectOut,
+                                                 &unimplemented);
+    if (!unimplemented) {
+      return script;
+    }
+
+    fprintf(stderr, "Falling back!\n");
+  }
+
   return CreateGlobalScript(info, srcBuf, sourceObjectOut);
 }
 

--- a/js/src/frontend/Frontend2.h
+++ b/js/src/frontend/Frontend2.h
@@ -7,17 +7,41 @@
 #ifndef frontend_Frontend2_h
 #define frontend_Frontend2_h
 
-#include "js/CompilationAndEvaluation.h"
-#include "js/SourceText.h"
-#include "vm/GlobalObject.h"
-#include "vm/JSAtom.h"
-#include "vm/JSContext.h"
-#include "vm/JSFunction.h"
-#include "vm/JSScript.h"
+#include "mozilla/Utf8.h"  // mozilla::Utf8Unit
 
-bool InitScript(JSContext* cx, JS::HandleScript script,
-                JS::HandleFunction functionProto);
-bool Create(JSContext* cx, const uint8_t* bytes, size_t length,
-            bool* unimplemented);
+#include <stddef.h>  // size_t
+#include <stdint.h>  // uint8_t
+
+#include "js/RootingAPI.h"  // JS::Handle
+#include "js/SourceText.h"  // JS::SourceText
+#include "vm/JSScript.h"    // JSScript
+
+struct JSContext;
+
+struct JsparagusResult;
+
+namespace js {
+
+class ScriptSourceObject;
+
+namespace frontend {
+
+class GlobalScriptInfo;
+
+// This is declarated as a class mostly to solve dependency around `friend`
+// declarations in the simple way.
+class Jsparagus {
+  static bool initScript(JSContext* cx, JS::Handle<JSScript*> script,
+                         const JsparagusResult& jsparagus);
+
+ public:
+  static JSScript* compileGlobalScript(
+      GlobalScriptInfo& info, JS::SourceText<mozilla::Utf8Unit>& srcBuf,
+      ScriptSourceObject** sourceObjectOut, bool* unimplemented);
+};
+
+}  // namespace frontend
+
+}  // namespace js
 
 #endif /* frontend_Frontend2_h */

--- a/js/src/vm/JSScript.h
+++ b/js/src/vm/JSScript.h
@@ -26,7 +26,6 @@
 
 #include "jstypes.h"
 
-#include "frontend-rs/frontend-rs.h"
 #include "frontend/BinASTRuntimeSupport.h"
 #include "frontend/NameAnalysisTypes.h"
 #include "gc/Barrier.h"
@@ -82,6 +81,7 @@ namespace frontend {
 struct BytecodeEmitter;
 class FunctionBox;
 class ModuleSharedContext;
+class Jsparagus;
 }  // namespace frontend
 
 namespace gc {
@@ -2496,8 +2496,7 @@ class JSScript : public js::BaseScript {
       js::HandleScriptSourceObject sourceObject,
       js::MutableHandle<JS::GCVector<js::Scope*>> scopes);
 
-  friend bool InitScript(JSContext* cx, js::HandleScript script,
-                         const JsparagusResult& jsparagus);
+  friend class js::frontend::Jsparagus;
 
  private:
   JSScript(js::HandleObject functionOrGlobal, uint8_t* stubEntry,


### PR DESCRIPTION
 * ~~`ReadOnlyCompileOptions.tryRustFrontend` and `CompileOptions.setTryRustFrontend` to tell frontend to try using rust frontend first~~
    *  (changed) `ContextOptions.{tryRustFrontend,setTryRustFrontend}` to tell frontend to try using rust frontend first
 * `frontend::CompileGlobalScript` with `Utf8Unit` checks the above option and try rust frontend first (what JS shell did in the previous patch)
 * removed `Execute`
 * Added `AutoFreeJsparagusResult` to free `JsparagusResult` in all cases
 * Added `Jsparagus` class, this is just to simplify `friend` declaration in `JSScript`
 * Changed `Create` to `Jsparagus::compileGlobalScript`, removing `Execute` part, and also using given compile options
 * Changed JS shell to pass `rustFrontend` to compile options
