### PR TITLE
Compare SpiderMonkey parsers.

### DIFF
--- a/js/src/frontend-rs/frontend-rs.h
+++ b/js/src/frontend-rs/frontend-rs.h
@@ -22,4 +22,8 @@ void free_jsparagus(JsparagusResult result);
 
 JsparagusResult run_jsparagus(const uint8_t *text, uintptr_t text_len);
 
+bool test_parse_module(const uint8_t *text, uintptr_t text_len);
+
+bool test_parse_script(const uint8_t *text, uintptr_t text_len);
+
 } // extern "C"

--- a/js/src/frontend-rs/src/lib.rs
+++ b/js/src/frontend-rs/src/lib.rs
@@ -3,7 +3,7 @@ extern crate parser;
 use ast::types::Program;
 use bumpalo;
 use emitter::{emit, EmitResult, EmitError};
-use parser::parse_script;
+use parser::{parse_module, parse_script};
 use std::{mem, slice, str};
 
 #[repr(C)]
@@ -68,6 +68,27 @@ pub unsafe extern "C" fn run_jsparagus(text: *const u8, text_len: usize) -> Jspa
                 unimplemented: true,
             }
         },
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn test_parse_script(text: *const u8, text_len: usize) -> bool {
+    let text = str::from_utf8(slice::from_raw_parts(text, text_len)).expect("Invalid UTF8");
+    let allocator = bumpalo::Bump::new();
+    match parse_script(&allocator, text) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn test_parse_module(text: *const u8, text_len: usize) -> bool {
+    let text = str::from_utf8(slice::from_raw_parts(text, text_len)).expect("Invalid UTF8");
+    let allocator = bumpalo::Bump::new();
+    match parse_module(&allocator, text) {
+        Ok(_) => true,
+        Err(_) => false,
     }
 }
 

--- a/js/src/frontend/Frontend2.cpp
+++ b/js/src/frontend/Frontend2.cpp
@@ -6,10 +6,13 @@
 
 #include "frontend/Frontend2.h"
 
+#include "mozilla/ScopeExit.h"
 #include "mozilla/Span.h"  // mozilla::Span
 
 #include <stddef.h>  // size_t
 #include <stdint.h>  // uint8_t, uint32_t
+
+#include "jsapi.h"
 
 #include "frontend-rs/frontend-rs.h"  // CVec, JsparagusResult, free_jsparagus, run_jsparagus
 #include "frontend/BytecodeCompilation.h"  // GlobalScriptInfo
@@ -156,6 +159,24 @@ JSScript* Jsparagus::compileGlobalScript(GlobalScriptInfo& info,
   }
 
   return script;
+}
+
+bool RustParseScript(JSContext* cx, const uint8_t* bytes, size_t length)
+{
+  if (test_parse_script(bytes, length)) {
+    return true;
+  }
+  JS_ReportErrorASCII(cx, "Rust parse script failed");
+  return false;
+}
+
+bool RustParseModule(JSContext* cx, const uint8_t* bytes, size_t length)
+{
+  if (test_parse_module(bytes, length)) {
+    return true;
+  }
+  JS_ReportErrorASCII(cx, "Rust parse module failed");
+  return false;
 }
 
 }  // namespace frontend

--- a/js/src/frontend/Frontend2.h
+++ b/js/src/frontend/Frontend2.h
@@ -40,6 +40,11 @@ class Jsparagus {
       ScriptSourceObject** sourceObjectOut, bool* unimplemented);
 };
 
+// Use the Rust frontend to parse and free the generated AST. Returns true if no
+// error were detected while parsing.
+MOZ_MUST_USE bool RustParseScript(JSContext* cx, const uint8_t* bytes, size_t length);
+MOZ_MUST_USE bool RustParseModule(JSContext* cx, const uint8_t* bytes, size_t length);
+
 }  // namespace frontend
 
 }  // namespace js

--- a/js/src/shell/OSObject.cpp
+++ b/js/src/shell/OSObject.cpp
@@ -8,8 +8,10 @@
 
 #include "shell/OSObject.h"
 
+#include "mozilla/ScopeExit.h"
 #include "mozilla/TextUtils.h"
 
+#include <dirent.h>
 #include <errno.h>
 #include <stdlib.h>
 #ifdef XP_WIN
@@ -20,6 +22,7 @@
 #  include <sys/wait.h>
 #  include <unistd.h>
 #endif
+#include <sys/types.h>
 
 #include "jsapi.h"
 // For JSFunctionSpecWithHelp
@@ -322,6 +325,100 @@ static bool osfile_readRelativeToScript(JSContext* cx, unsigned argc,
   return ReadFile(cx, argc, vp, true);
 }
 
+static bool osfile_listDir(JSContext* cx, unsigned argc, Value* vp) {
+  CallArgs args = CallArgsFromVp(argc, vp);
+
+  if (args.length() != 1) {
+    JS_ReportErrorASCII(cx, "os.file.listDir requires 1 argument");
+    return false;
+  }
+
+  if (!args[0].isString()) {
+    JS_ReportErrorNumberASCII(cx, js::shell::my_GetErrorMessage, nullptr,
+                              JSSMSG_INVALID_ARGS, "os.file.listDir");
+    return false;
+  }
+
+  RootedString givenPath(cx, args[0].toString());
+  RootedString str(cx, ResolvePath(cx, givenPath, ScriptRelative));
+  if (!str) {
+    return false;
+  }
+
+  UniqueChars pathname = JS_EncodeStringToLatin1(cx, str);
+  if (!pathname) {
+    JS_ReportErrorASCII(cx, "os.file.listDir cannot convert path to Latin1");
+    return false;
+  }
+
+  RootedValueVector elems(cx);
+  auto append = [&](const char* name) -> bool {
+    if (!(str = JS_NewStringCopyZ(cx, name))) {
+      return false;
+    }
+    if (!elems.append(StringValue(str))) {
+      js::ReportOutOfMemory(cx);
+      return false;
+    }
+    return true;
+  };
+
+#if defined(XP_UNIX)
+  {
+    DIR* dir = opendir(pathname.get());
+    if (!dir) {
+      JS_ReportErrorASCII(cx, "os.file.listDir is unable to open: %s",
+                          pathname.get());
+      return false;
+    }
+    auto close = mozilla::MakeScopeExit([&] {
+      if (closedir(dir) != 0) {
+        MOZ_CRASH("Could not close dir");
+      }
+    });
+
+    while (struct dirent* entry = readdir(dir)) {
+      if (!append(entry->d_name)) {
+        return false;
+      }
+    }
+  }
+#elif defined(XP_WIN)
+  {
+    const size_t pathlen = strlen(path);
+    Vector<char> pattern(cx);
+    if (!pattern.append(pathname.get(), pathlen) ||
+        !pattern.append(PathSeparator) ||
+        !pattern.append("*", 2)) {
+      js::ReportOutOfMemory(cx);
+      return false;
+    }
+
+    WIN32_FIND_DATA FindFileData;
+    HANDLE hFind = FindFirstFile(pattern.begin(), &FindFileData);
+    auto close = mozilla::MakeScopeExit([&] {
+      if (!FindClose(hFind)) {
+        MOZ_CRASH("Could not close Find");
+      }
+    });
+    for (bool found = (hFind != INVALID_HANDLE_VALUE); found;
+         found = FindNextFile(hFind, &FindFileData)) {
+      if (!append(FindFileData.cFileName)) {
+        return false;
+      }
+    }
+  }
+#endif
+
+  JSObject* array = JS_NewArrayObject(cx, elems);
+  if (!array) {
+    return false;
+  }
+
+  args.rval().setObject(*array);
+  return true;
+}
+
 static bool osfile_writeTypedArrayToFile(JSContext* cx, unsigned argc,
                                          Value* vp) {
   CallArgs args = CallArgsFromVp(argc, vp);
@@ -611,6 +708,12 @@ static const JSFunctionSpecWithHelp osfile_functions[] = {
 "  Read entire contents of filename. Returns a string, unless \"binary\" is passed\n"
 "  as the second argument, in which case it returns a Uint8Array. Filename is\n"
 "  relative to the current working directory."),
+
+    JS_FN_HELP("listDir", osfile_listDir, 1, 0,
+"listDir(filename)",
+"  Read entire contents of a directory. The \"filename\" parameter is relate to the\n"
+"  current working directory.Returns a list of filenames within the given directory.\n"
+"  Note that \".\" and \"..\" are also listed."),
 
     JS_FN_HELP("readRelativeToScript", osfile_readRelativeToScript, 1, 0,
 "readRelativeToScript(filename, [\"binary\"])",

--- a/js/src/shell/js.cpp
+++ b/js/src/shell/js.cpp
@@ -76,6 +76,7 @@
 #if defined(JS_BUILD_BINAST)
 #  include "frontend/BinASTParser.h"
 #endif  // defined(JS_BUILD_BINAST)
+#include "frontend/Frontend2.h"
 #include "frontend/ModuleSharedContext.h"
 #include "frontend/ParseInfo.h"
 #include "frontend/Parser.h"
@@ -5246,79 +5247,15 @@ static bool BinParse(JSContext* cx, unsigned argc, Value* vp) {
 
 #endif  // defined(JS_BUILD_BINAST)
 
-static bool Parse(JSContext* cx, unsigned argc, Value* vp) {
+template <typename Unit>
+static bool FullParseTest(JSContext* cx, const JS::ReadOnlyCompileOptions& options,
+                          const Unit* units, size_t length, ParseInfo& parseInfo,
+                          ScriptSourceObject* sourceObject, js::frontend::ParseGoal goal) {
   using namespace js::frontend;
-
-  CallArgs args = CallArgsFromVp(argc, vp);
-
-  if (!args.requireAtLeast(cx, "parse", 1)) {
-    return false;
-  }
-  if (!args[0].isString()) {
-    const char* typeName = InformalValueTypeName(args[0]);
-    JS_ReportErrorASCII(cx, "expected string to parse, got %s", typeName);
-    return false;
-  }
-
-  frontend::ParseGoal goal = frontend::ParseGoal::Script;
-
-  if (args.length() >= 2) {
-    if (!args[1].isObject()) {
-      const char* typeName = InformalValueTypeName(args[1]);
-      JS_ReportErrorASCII(cx, "expected object (options) to parse, got %s",
-                          typeName);
-      return false;
-    }
-    RootedObject objOptions(cx, &args[1].toObject());
-
-    RootedValue optionModule(cx);
-    if (!JS_GetProperty(cx, objOptions, "module", &optionModule)) {
-      return false;
-    }
-
-    if (optionModule.isBoolean()) {
-      if (optionModule.toBoolean()) {
-        goal = frontend::ParseGoal::Module;
-      }
-    } else if (!optionModule.isUndefined()) {
-      const char* typeName = InformalValueTypeName(optionModule);
-      JS_ReportErrorASCII(cx, "option `module` should be a boolean, got %s",
-                          typeName);
-      return false;
-    }
-  }
-
-  JSString* scriptContents = args[0].toString();
-
-  AutoStableStringChars stableChars(cx);
-  if (!stableChars.initTwoByte(cx, scriptContents)) {
-    return false;
-  }
-
-  size_t length = scriptContents->length();
-  const char16_t* chars = stableChars.twoByteRange().begin().get();
-
-  CompileOptions options(cx);
-  options.setIntroductionType("js shell parse").setFileAndLine("<string>", 1);
-  if (goal == frontend::ParseGoal::Module) {
-    // See frontend::CompileModule.
-    options.setForceStrictMode();
-    options.allowHTMLComments = false;
-  }
-
-  LifoAllocScope allocScope(&cx->tempLifoAlloc());
-  ParseInfo parseInfo(cx, allocScope);
-
-  RootedScriptSourceObject sourceObject(
-      cx, frontend::CreateScriptSourceObject(cx, options, Nothing()));
-  if (!sourceObject) {
-    return false;
-  }
-
-  Parser<FullParseHandler, char16_t> parser(cx, options, chars, length,
-                                            /* foldConstants = */ false,
-                                            parseInfo, nullptr, nullptr,
-                                            sourceObject, goal);
+  Parser<FullParseHandler, Unit> parser(cx, options, units, length,
+                                        /* foldConstants = */ false,
+                                        parseInfo, nullptr, nullptr,
+                                        sourceObject, goal);
   if (!parser.checkOptions()) {
     return false;
   }
@@ -5348,6 +5285,125 @@ static bool Parse(JSContext* cx, unsigned argc, Value* vp) {
   js::Fprinter out(stderr);
   DumpParseTree(pn, out);
 #endif
+  return true;
+}
+
+static bool Parse(JSContext* cx, unsigned argc, Value* vp) {
+  using namespace js::frontend;
+
+  CallArgs args = CallArgsFromVp(argc, vp);
+
+  if (!args.requireAtLeast(cx, "parse", 1)) {
+    return false;
+  }
+  if (!args[0].isString()) {
+    const char* typeName = InformalValueTypeName(args[0]);
+    JS_ReportErrorASCII(cx, "expected string to parse, got %s", typeName);
+    return false;
+  }
+
+  frontend::ParseGoal goal = frontend::ParseGoal::Script;
+  bool rustFrontend = false;
+
+  if (args.length() >= 2) {
+    if (!args[1].isObject()) {
+      const char* typeName = InformalValueTypeName(args[1]);
+      JS_ReportErrorASCII(cx, "expected object (options) to parse, got %s",
+                          typeName);
+      return false;
+    }
+    RootedObject objOptions(cx, &args[1].toObject());
+
+    RootedValue optionModule(cx);
+    if (!JS_GetProperty(cx, objOptions, "module", &optionModule)) {
+      return false;
+    }
+
+    if (optionModule.isBoolean()) {
+      if (optionModule.toBoolean()) {
+        goal = frontend::ParseGoal::Module;
+      }
+    } else if (!optionModule.isUndefined()) {
+      const char* typeName = InformalValueTypeName(optionModule);
+      JS_ReportErrorASCII(cx, "option `module` should be a boolean, got %s",
+                          typeName);
+      return false;
+    }
+
+    RootedValue optionRustFrontend(cx);
+    if (!JS_GetProperty(cx, objOptions, "rustFrontend", &optionRustFrontend)) {
+      return false;
+    }
+
+    if (optionRustFrontend.isBoolean()) {
+      rustFrontend = optionRustFrontend.toBoolean();
+    } else if (!optionRustFrontend.isUndefined()) {
+      const char* typeName = InformalValueTypeName(optionRustFrontend);
+      JS_ReportErrorASCII(cx, "option `rustFrontend` should be a boolean, got %s",
+                          typeName);
+      return false;
+    }
+  }
+
+  JSString* scriptContents = args[0].toString();
+
+  AutoStableStringChars stableChars(cx);
+  if (!stableChars.init(cx, scriptContents)) {
+    return false;
+  }
+
+  size_t length = scriptContents->length();
+  if (rustFrontend) {
+    if (stableChars.isLatin1()) {
+      const Latin1Char* chars = stableChars.latin1Range().begin().get();
+      if (goal == frontend::ParseGoal::Script) {
+        if (!RustParseScript(cx, chars, length)) {
+          return false;
+        }
+      } else {
+        if (!RustParseModule(cx, chars, length)) {
+          return false;
+        }
+      }
+      args.rval().setUndefined();
+      return true;
+    }
+    JS_ReportErrorASCII(cx, "Rust parser does not support two-byte chars yet");
+    return false;
+  }
+
+  CompileOptions options(cx);
+  options.setIntroductionType("js shell parse").setFileAndLine("<string>", 1);
+  if (goal == frontend::ParseGoal::Module) {
+    // See frontend::CompileModule.
+    options.setForceStrictMode();
+    options.allowHTMLComments = false;
+  }
+
+  LifoAllocScope allocScope(&cx->tempLifoAlloc());
+  ParseInfo parseInfo(cx, allocScope);
+
+  RootedScriptSourceObject sourceObject(
+      cx, frontend::CreateScriptSourceObject(cx, options, Nothing()));
+  if (!sourceObject) {
+    return false;
+  }
+
+  if (stableChars.isLatin1()) {
+    const Latin1Char* chars_ = stableChars.latin1Range().begin().get();
+    auto chars = reinterpret_cast<const mozilla::Utf8Unit*>(chars_);
+    if (!FullParseTest<mozilla::Utf8Unit>(cx, options, chars, length,
+                                          parseInfo, sourceObject, goal)) {
+      return false;
+    }
+  } else {
+    MOZ_ASSERT(stableChars.isTwoByte());
+    const char16_t* chars = stableChars.twoByteRange().begin().get();
+    if (!FullParseTest<char16_t>(cx, options, chars, length,
+                                 parseInfo, sourceObject, goal)) {
+      return false;
+    }
+  }
   args.rval().setUndefined();
   return true;
 }


### PR DESCRIPTION
This pull request change the `Parse` function to call the experimental rust parser when called with `{ rustFrontend: true }`.

Then it adds `os.file.listDir` to list all file names in a directory. This can be used by some harness to iterate over all files in a directory.

For example, [this script](https://gist.github.com/nbp/1d922a1ae6e22f5ef42269d12e0bc919) , once placed at the root of [real-js-samples](https://github.com/Yoric/real-js-samples) repository, will iterate over all scripts and parse them.