### PR TITLE
 Propagate SyntaxError and Unimplemented error from parser (fixes #13)

### DIFF
--- a/js/src/frontend-rs/frontend-rs.h
+++ b/js/src/frontend-rs/frontend-rs.h
@@ -13,6 +13,7 @@ struct CVec {
 struct JsparagusResult {
   CVec<uint8_t> bytecode;
   CVec<CVec<uint8_t>> strings;
+  CVec<uint8_t> error;
   bool unimplemented;
 };
 

--- a/js/src/frontend-rs/src/lib.rs
+++ b/js/src/frontend-rs/src/lib.rs
@@ -3,7 +3,7 @@ extern crate parser;
 use ast::types::Program;
 use bumpalo;
 use emitter::{emit, EmitResult, EmitError};
-use parser::{parse_module, parse_script};
+use parser::{parse_module, parse_script, ParseError};
 use std::{mem, slice, str};
 
 #[repr(C)]
@@ -41,32 +41,42 @@ impl<T> CVec<T> {
 pub struct JsparagusResult {
     bytecode: CVec<u8>,
     strings: CVec<CVec<u8>>,
+    error: CVec<u8>,
     unimplemented: bool,
+}
+
+enum JsparagusError {
+    GenericError(String),
+    NotImplemented,
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn run_jsparagus(text: *const u8, text_len: usize) -> JsparagusResult {
     let text = str::from_utf8(slice::from_raw_parts(text, text_len)).expect("Invalid UTF8");
     match jsparagus(text) {
-        Ok(mut result) =>
-            JsparagusResult {
-                bytecode: CVec::from(result.bytecode),
-                strings: CVec::from(
-                    result
-                        .strings
-                        .drain(..)
-                        .map(|s| CVec::from(s.into_bytes()))
-                        .collect(),
-                ),
-                unimplemented: false,
-            },
-        Err(EmitError::NotImplemented(message)) => {
-            println!("Unimplemented: {}", message);
-            JsparagusResult {
-                bytecode: CVec::empty(),
-                strings: CVec::empty(),
-                unimplemented: true,
-            }
+        Ok(mut result) => JsparagusResult {
+            bytecode: CVec::from(result.bytecode),
+            strings: CVec::from(
+                result
+                    .strings
+                    .drain(..)
+                    .map(|s| CVec::from(s.into_bytes()))
+                    .collect(),
+            ),
+            error: CVec::empty(),
+            unimplemented: false,
+        },
+        Err(JsparagusError::GenericError(message)) => JsparagusResult {
+            bytecode: CVec::empty(),
+            strings: CVec::empty(),
+            error: CVec::from(format!("{}\0", message).into_bytes()),
+            unimplemented: false,
+        },
+        Err(JsparagusError::NotImplemented) => JsparagusResult {
+            bytecode: CVec::empty(),
+            strings: CVec::empty(),
+            error: CVec::empty(),
+            unimplemented: true,
         },
     }
 }
@@ -104,13 +114,32 @@ pub unsafe extern "C" fn free_jsparagus(result: JsparagusResult) {
     for v in result.strings.into() {
         let _ = v.into();
     }
+    let _ = result.error.into();
     //Vec::from_raw_parts(bytecode.data, bytecode.len, bytecode.capacity);
 }
 
-fn jsparagus(text: &str) -> Result<EmitResult, EmitError> {
+fn jsparagus(text: &str) -> Result<EmitResult, JsparagusError> {
     let allocator = bumpalo::Bump::new();
-    let parse_result = parse_script(&allocator, text).expect("Failed to parse");
-    emit(&mut Program::Script(parse_result.unbox()))
+    let parse_result = match parse_script(&allocator, text) {
+        Ok(result) => result,
+        Err(err) => match err {
+            ParseError::NotImplemented(_) => {
+                println!("Unimplemented: {}", err.message());
+                return Err(JsparagusError::NotImplemented);
+            }
+            _ => {
+                return Err(JsparagusError::GenericError(err.message()));
+            }
+        },
+    };
+
+    match emit(&mut Program::Script(parse_result.unbox())) {
+        Ok(result) => Ok(result),
+        Err(EmitError::NotImplemented(message)) => {
+            println!("Unimplemented: {}", message);
+            return Err(JsparagusError::NotImplemented);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/js/src/frontend/Frontend2.cpp
+++ b/js/src/frontend/Frontend2.cpp
@@ -118,6 +118,13 @@ JSScript* Jsparagus::compileGlobalScript(GlobalScriptInfo& info,
   JsparagusResult jsparagus = run_jsparagus(bytes, length);
   AutoFreeJsparagusResult afjr(&jsparagus);
 
+  if (jsparagus.error.data) {
+    *unimplemented = false;
+    JS_ReportErrorASCII(cx, "%s",
+                        reinterpret_cast<const char*>(jsparagus.error.data));
+    return nullptr;
+  }
+
   if (jsparagus.unimplemented) {
     *unimplemented = true;
     return nullptr;


### PR DESCRIPTION
Added `JsparagusResult.error` field to return error message.
If the field isn't empty, it means that the parser hits some error.
