### PR TITLE
Include maximum_stack_depth and num_ic_entries in Rust frontend output.

### DIFF
--- a/js/src/frontend-rs/frontend-rs.h
+++ b/js/src/frontend-rs/frontend-rs.h
@@ -11,10 +11,19 @@ struct CVec {
 };
 
 struct JsparagusResult {
+  bool unimplemented;
+  CVec<uint8_t> error;
   CVec<uint8_t> bytecode;
   CVec<CVec<uint8_t>> strings;
-  CVec<uint8_t> error;
-  bool unimplemented;
+  /// Maximum stack depth before any instruction.
+  ///
+  /// This value is a function of `bytecode`: there's only one correct value
+  /// for a given script.
+  uint32_t maximum_stack_depth;
+  /// Number of instructions in this script that have IC entries.
+  ///
+  /// A function of `bytecode`. See `JOF_IC`.
+  uint32_t num_ic_entries;
 };
 
 extern "C" {

--- a/js/src/vm/JSScript.h
+++ b/js/src/vm/JSScript.h
@@ -1709,6 +1709,7 @@ class alignas(uint32_t) ImmutableScriptData final {
                 "Structure packing is broken");
 
   friend class ::JSScript;
+  friend class ::js::frontend::Jsparagus;
 
  private:
   // Offsets (in bytes) from 'this' to each component array. The delta between


### PR DESCRIPTION
With this change, `dis();` works instead of crashing.