### PR TITLE
Share more code with BytecodeEmitter (fixes jsparagus#86)

### DIFF
--- a/js/src/builtin/Eval.cpp
+++ b/js/src/builtin/Eval.cpp
@@ -119,7 +119,7 @@ class EvalScriptGuard {
   }
 
   void setNewScript(JSScript* script) {
-    // JSScript::initFromEmitter has already called js_CallNewScriptHook.
+    // JSScript::fullyInitFromStencil has already called js_CallNewScriptHook.
     MOZ_ASSERT(!script_ && script);
     script_ = script;
   }

--- a/js/src/frontend/BCEScriptStencil.cpp
+++ b/js/src/frontend/BCEScriptStencil.cpp
@@ -90,7 +90,7 @@ bool BCEScriptStencil::finishGCThings(
                                                    gcthings);
 }
 
-void BCEScriptStencil::initAtomMap(GCPtrAtom* atoms) const {
+bool BCEScriptStencil::initAtomMap(JSContext* cx, GCPtrAtom* atoms) const {
   const AtomIndexMap& indices = *bce_.perScriptData().atomIndices();
 
   for (AtomIndexMap::Range r = indices.all(); !r.empty(); r.popFront()) {
@@ -99,6 +99,7 @@ void BCEScriptStencil::initAtomMap(GCPtrAtom* atoms) const {
     MOZ_ASSERT(index < indices.count());
     atoms[index].init(atom);
   }
+  return true;
 }
 
 void BCEScriptStencil::finishResumeOffsets(

--- a/js/src/frontend/BCEScriptStencil.cpp
+++ b/js/src/frontend/BCEScriptStencil.cpp
@@ -1,0 +1,120 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: set ts=8 sts=2 et sw=2 tw=80:
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "frontend/BCEScriptStencil.h"
+
+#include "frontend/AbstractScope.h"    // AbstractScope
+#include "frontend/BytecodeEmitter.h"  // BytecodeEmitter
+#include "frontend/BytecodeSection.h"  // BytecodeSection, PerScriptData
+
+using namespace js;
+using namespace js::frontend;
+
+bool BCEScriptStencil::init() {
+  lineno = bce_.firstLine;
+  column = bce_.firstColumn;
+
+  natoms = bce_.perScriptData().atomIndices()->count();
+
+  ngcthings = bce_.perScriptData().gcThingList().length();
+
+  numResumeOffsets = bce_.bytecodeSection().resumeOffsetList().length();
+  numScopeNotes = bce_.bytecodeSection().scopeNoteList().length();
+  numTryNotes = bce_.bytecodeSection().tryNoteList().length();
+
+  mainOffset = bce_.mainOffset();
+  nfixed = bce_.maxFixedSlots;
+
+  uint64_t nslots64 =
+      nfixed + static_cast<uint64_t>(bce_.bytecodeSection().maxStackDepth());
+  if (nslots64 > UINT32_MAX) {
+    bce_.reportError(nullptr, JSMSG_NEED_DIET, js_script_str);
+    return false;
+  }
+  nslots = nslots64;
+
+  bodyScopeIndex = bce_.bodyScopeIndex;
+  numICEntries = bce_.bytecodeSection().numICEntries();
+  numBytecodeTypeSets = bce_.bytecodeSection().numTypeSets();
+
+  strict = bce_.sc->strict();
+  bindingsAccessedDynamically = bce_.sc->bindingsAccessedDynamically();
+  hasCallSiteObj = bce_.sc->hasCallSiteObj();
+  isForEval = bce_.sc->isEvalContext();
+  isModule = bce_.sc->isModuleContext();
+  isFunction = bce_.sc->isFunctionBox();
+  hasNonSyntacticScope =
+      bce_.outermostScope().hasOnChain(ScopeKind::NonSyntactic);
+  needsFunctionEnvironmentObjects = getNeedsFunctionEnvironmentObjects();
+  hasModuleGoal = bce_.sc->hasModuleGoal();
+
+  code = bce_.bytecodeSection().code();
+  notes = bce_.bytecodeSection().notes();
+
+  if (isFunction) {
+    functionBox = bce_.sc->asFunctionBox();
+  }
+
+  return true;
+}
+
+bool BCEScriptStencil::getNeedsFunctionEnvironmentObjects() const {
+  // See JSFunction::needsCallObject()
+  js::AbstractScope bodyScope = bce_.bodyScope();
+  if (bodyScope.kind() == js::ScopeKind::Function) {
+    if (bodyScope.hasEnvironment()) {
+      return true;
+    }
+  }
+
+  // See JSScript::maybeNamedLambdaScope()
+  js::AbstractScope outerScope = bce_.outermostScope();
+  if (outerScope.kind() == js::ScopeKind::NamedLambda ||
+      outerScope.kind() == js::ScopeKind::StrictNamedLambda) {
+    MOZ_ASSERT(bce_.sc->asFunctionBox()->isNamedLambda());
+
+    if (outerScope.hasEnvironment()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool BCEScriptStencil::finishGCThings(
+    JSContext* cx, mozilla::Span<JS::GCCellPtr> gcthings) const {
+  return bce_.perScriptData().gcThingList().finish(cx, bce_.parseInfo,
+                                                   gcthings);
+}
+
+void BCEScriptStencil::initAtomMap(GCPtrAtom* atoms) const {
+  const AtomIndexMap& indices = *bce_.perScriptData().atomIndices();
+
+  for (AtomIndexMap::Range r = indices.all(); !r.empty(); r.popFront()) {
+    JSAtom* atom = r.front().key();
+    uint32_t index = r.front().value();
+    MOZ_ASSERT(index < indices.count());
+    atoms[index].init(atom);
+  }
+}
+
+void BCEScriptStencil::finishResumeOffsets(
+    mozilla::Span<uint32_t> resumeOffsets) const {
+  bce_.bytecodeSection().resumeOffsetList().finish(resumeOffsets);
+}
+
+void BCEScriptStencil::finishScopeNotes(
+    mozilla::Span<ScopeNote> scopeNotes) const {
+  bce_.bytecodeSection().scopeNoteList().finish(scopeNotes);
+}
+
+void BCEScriptStencil::finishTryNotes(mozilla::Span<JSTryNote> tryNotes) const {
+  bce_.bytecodeSection().tryNoteList().finish(tryNotes);
+}
+
+void BCEScriptStencil::finishInnerFunctions() const {
+  bce_.perScriptData().gcThingList().finishInnerFunctions();
+}

--- a/js/src/frontend/BCEScriptStencil.h
+++ b/js/src/frontend/BCEScriptStencil.h
@@ -39,7 +39,7 @@ class BCEScriptStencil : public ScriptStencil {
 
   virtual bool finishGCThings(JSContext* cx,
                               mozilla::Span<JS::GCCellPtr> gcthings) const;
-  virtual void initAtomMap(GCPtrAtom* atoms) const;
+  virtual bool initAtomMap(JSContext* cx, GCPtrAtom* atoms) const;
   virtual void finishResumeOffsets(mozilla::Span<uint32_t> resumeOffsets) const;
   virtual void finishScopeNotes(mozilla::Span<ScopeNote> scopeNotes) const;
   virtual void finishTryNotes(mozilla::Span<JSTryNote> tryNotes) const;

--- a/js/src/frontend/BCEScriptStencil.h
+++ b/js/src/frontend/BCEScriptStencil.h
@@ -1,0 +1,52 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: set ts=8 sts=2 et sw=2 tw=80:
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef frontend_BCEScriptStencil_h
+#define frontend_BCEScriptStencil_h
+
+#include "mozilla/Span.h"  // mozilla::Span
+
+#include <stdint.h>  // int32_t
+
+#include "frontend/Stencil.h"  // ScriptStencil
+#include "gc/Barrier.h"        // GCPtrAtom
+#include "js/HeapAPI.h"        // JS::GCCellPtr
+#include "vm/JSScript.h"       // JSTryNote, ScopeNote
+
+struct JSContext;
+
+namespace js {
+
+namespace frontend {
+
+struct BytecodeEmitter;
+
+class BCEScriptStencil : public ScriptStencil {
+  BytecodeEmitter& bce_;
+
+  bool getNeedsFunctionEnvironmentObjects() const;
+
+ public:
+  explicit BCEScriptStencil(BytecodeEmitter& bce) : bce_(bce) {}
+
+  // Initialize fields.
+  // This is done here instead of constructor because calculating some field
+  // is fallible.
+  bool init();
+
+  virtual bool finishGCThings(JSContext* cx,
+                              mozilla::Span<JS::GCCellPtr> gcthings) const;
+  virtual void initAtomMap(GCPtrAtom* atoms) const;
+  virtual void finishResumeOffsets(mozilla::Span<uint32_t> resumeOffsets) const;
+  virtual void finishScopeNotes(mozilla::Span<ScopeNote> scopeNotes) const;
+  virtual void finishTryNotes(mozilla::Span<JSTryNote> tryNotes) const;
+  virtual void finishInnerFunctions() const;
+};
+
+} /* namespace frontend */
+} /* namespace js */
+
+#endif /* frontend_BCEScriptStencil_h */

--- a/js/src/frontend/BytecodeCompilation.h
+++ b/js/src/frontend/BytecodeCompilation.h
@@ -33,6 +33,7 @@ namespace js {
 
 namespace frontend {
 
+struct BytecodeEmitter;
 class EitherParser;
 
 template <typename Unit>

--- a/js/src/frontend/BytecodeEmitter.cpp
+++ b/js/src/frontend/BytecodeEmitter.cpp
@@ -27,6 +27,7 @@
 
 #include "ds/Nestable.h"  // Nestable
 #include "frontend/AbstractScope.h"
+#include "frontend/BCEScriptStencil.h"           // BCEScriptStencil
 #include "frontend/BytecodeControlStructures.h"  // NestableControl, BreakableControl, LabelControl, LoopControl, TryFinallyControl
 #include "frontend/CallOrNewEmitter.h"           // CallOrNewEmitter
 #include "frontend/CForEmitter.h"                // CForEmitter
@@ -2485,7 +2486,12 @@ bool BytecodeEmitter::emitScript(ParseNode* body) {
     return false;
   }
 
-  if (!JSScript::fullyInitFromEmitter(cx, script, this)) {
+  BCEScriptStencil stencil(*this);
+  if (!stencil.init()) {
+    return false;
+  }
+
+  if (!JSScript::fullyInitFromStencil(cx, script, stencil)) {
     return false;
   }
 

--- a/js/src/frontend/BytecodeEmitter.h
+++ b/js/src/frontend/BytecodeEmitter.h
@@ -113,7 +113,7 @@ struct MOZ_STACK_CLASS BytecodeEmitter {
 
   ParseInfo& parseInfo;
 
-  // First line and column, for JSScript::initFromEmitter.
+  // First line and column, for JSScript::fullyInitFromStencil.
   unsigned firstLine = 0;
   unsigned firstColumn = 0;
 

--- a/js/src/frontend/Frontend2.h
+++ b/js/src/frontend/Frontend2.h
@@ -31,9 +31,6 @@ class GlobalScriptInfo;
 // This is declarated as a class mostly to solve dependency around `friend`
 // declarations in the simple way.
 class Jsparagus {
-  static bool initScript(JSContext* cx, JS::Handle<JSScript*> script,
-                         const JsparagusResult& jsparagus);
-
  public:
   static JSScript* compileGlobalScript(
       GlobalScriptInfo& info, JS::SourceText<mozilla::Utf8Unit>& srcBuf,
@@ -42,8 +39,10 @@ class Jsparagus {
 
 // Use the Rust frontend to parse and free the generated AST. Returns true if no
 // error were detected while parsing.
-MOZ_MUST_USE bool RustParseScript(JSContext* cx, const uint8_t* bytes, size_t length);
-MOZ_MUST_USE bool RustParseModule(JSContext* cx, const uint8_t* bytes, size_t length);
+MOZ_MUST_USE bool RustParseScript(JSContext* cx, const uint8_t* bytes,
+                                  size_t length);
+MOZ_MUST_USE bool RustParseModule(JSContext* cx, const uint8_t* bytes,
+                                  size_t length);
 
 }  // namespace frontend
 

--- a/js/src/frontend/FunctionEmitter.cpp
+++ b/js/src/frontend/FunctionEmitter.cpp
@@ -9,6 +9,7 @@
 #include "mozilla/Assertions.h"  // MOZ_ASSERT
 
 #include "builtin/ModuleObject.h"          // ModuleObject
+#include "frontend/BCEScriptStencil.h"     // BCEScriptStencil
 #include "frontend/BytecodeEmitter.h"      // BytecodeEmitter
 #include "frontend/ModuleSharedContext.h"  // ModuleSharedContext
 #include "frontend/NameAnalysisTypes.h"    // NameLocation
@@ -744,7 +745,12 @@ bool FunctionScriptEmitter::initScript(
     const FieldInitializers& fieldInitializers) {
   MOZ_ASSERT(state_ == State::EndBody);
 
-  if (!JSScript::fullyInitFromEmitter(bce_->cx, bce_->script, bce_)) {
+  BCEScriptStencil stencil(*bce_);
+  if (!stencil.init()) {
+    return false;
+  }
+
+  if (!JSScript::fullyInitFromStencil(bce_->cx, bce_->script, stencil)) {
     return false;
   }
 

--- a/js/src/frontend/Stencil.h
+++ b/js/src/frontend/Stencil.h
@@ -7,18 +7,46 @@
 #ifndef frontend_Stencil_h
 #define frontend_Stencil_h
 
-#include "frontend/AbstractScope.h"
-#include "frontend/TypedIndex.h"
-#include "gc/AllocKind.h"
-#include "gc/Rooting.h"
-#include "js/RegExpFlags.h"
-#include "vm/BigIntType.h"
-#include "vm/JSFunction.h"
-#include "vm/JSScript.h"
-#include "vm/Scope.h"
+#include "mozilla/Assertions.h"  // MOZ_ASSERT, MOZ_RELEASE_ASSERT
+#include "mozilla/Maybe.h"       // mozilla::{Maybe, Nothing}
+#include "mozilla/Range.h"       // mozilla::Range
+#include "mozilla/Span.h"        // mozilla::Span
+
+#include <stdint.h>  // char16_t, uint8_t, uint32_t
+#include <stdlib.h>  // size_t
+
+#include "frontend/AbstractScope.h"      // AbstractScope, ScopeIndex
+#include "frontend/NameAnalysisTypes.h"  // {AtomVector, FunctionBoxVector}
+#include "frontend/TypedIndex.h"         // TypedIndex
+#include "gc/AllocKind.h"                // gc::AllocKind
+#include "gc/Barrier.h"                  // HeapPtr, GCPtrAtom
+#include "gc/Rooting.h"  // HandleAtom, HandleModuleObject, HandleScriptSourceObject, MutableHandleScope
+#include "js/RegExpFlags.h"  // JS::RegExpFlags
+#include "js/RootingAPI.h"   // Handle
+#include "js/UniquePtr.h"    // UniquePtr
+#include "js/Utility.h"      // JS::FreePolicy, UniqueTwoByteChars
+#include "js/Vector.h"       // js::Vector
+#include "util/Text.h"       // DuplicateString
+#include "vm/BigIntType.h"   // ParseBigIntLiteral
+#include "vm/JSFunction.h"   // FunctionFlags
+#include "vm/JSScript.h"  // GeneratorKind, FunctionAsyncKind, ScopeNote, JSTryNote, FieldInitializers
+#include "vm/Runtime.h"  // ReportOutOfMemory
+#include "vm/Scope.h"  // BaseScopeData, FunctionScope, LexicalScope, VarScope, GlobalScope, EvalScope, ModuleScope
+#include "vm/ScopeKind.h"  // ScopeKind
+
+struct JSContext;
+class JSAtom;
+class JSFunction;
+class JSTracer;
 
 namespace js {
+
+class Shape;
+
 namespace frontend {
+
+struct ParseInfo;
+class FunctionBox;
 
 // [SMDOC] Script Stencil (Frontend Representation)
 //
@@ -333,6 +361,78 @@ class ScopeCreationData {
     }
     return data<SpecificScopeType>().nextFrameSlot;
   }
+};
+
+// Data used to instantiate the non-lazy script.
+class ScriptStencil {
+ public:
+  // See `BaseScript::{lineno_,column_}`.
+  unsigned lineno = 0;
+  unsigned column = 0;
+
+  // See `initAtomMap` method.
+  uint32_t natoms = 0;
+
+  // See `finishGCThings` method.
+  uint32_t ngcthings = 0;
+
+  // See `finishResumeOffsets` method.
+  uint32_t numResumeOffsets = 0;
+
+  // See `finishScopeNotes` method.
+  uint32_t numScopeNotes = 0;
+
+  // See `finishTryNotes` method.
+  uint32_t numTryNotes = 0;
+
+  // See `ImmutableScriptData`.
+  uint32_t mainOffset = 0;
+  uint32_t nfixed = 0;
+  uint32_t nslots = 0;
+  uint32_t bodyScopeIndex = 0;
+  uint32_t numICEntries = 0;
+  uint32_t numBytecodeTypeSets = 0;
+
+  // `See BaseScript::ImmutableFlags`.
+  bool strict = false;
+  bool bindingsAccessedDynamically = false;
+  bool hasCallSiteObj = false;
+  bool isForEval = false;
+  bool isModule = false;
+  bool isFunction = false;
+  bool hasNonSyntacticScope = false;
+  bool needsFunctionEnvironmentObjects = false;
+  bool hasModuleGoal = false;
+
+  mozilla::Span<const jsbytecode> code;
+  mozilla::Span<const jssrcnote> notes;
+
+  js::frontend::FunctionBox* functionBox = nullptr;
+
+  // Store all GC things into `gcthings`.
+  // `gcthings.Length()` is `this.ngcthings`.
+  virtual bool finishGCThings(JSContext* cx,
+                              mozilla::Span<JS::GCCellPtr> gcthings) const = 0;
+
+  // Store all atoms into `atoms`
+  // `atoms` is the pointer to `this.natoms`-length array of `GCPtrAtom`.
+  virtual void initAtomMap(GCPtrAtom* atoms) const = 0;
+
+  // Store all resume offsets into `resumeOffsets`
+  // `resumeOffsets.Length()` is `this.numResumeOffsets`.
+  virtual void finishResumeOffsets(
+      mozilla::Span<uint32_t> resumeOffsets) const = 0;
+
+  // Store all scope notes into `scopeNotes`.
+  // `scopeNotes.Length()` is `this.numScopeNotes`.
+  virtual void finishScopeNotes(mozilla::Span<ScopeNote> scopeNotes) const = 0;
+
+  // Store all try notes into `tryNotes`.
+  // `tryNotes.Length()` is `this.numTryNotes`.
+  virtual void finishTryNotes(mozilla::Span<JSTryNote> tryNotes) const = 0;
+
+  // Call `FunctionBox::finish` for all inner functions.
+  virtual void finishInnerFunctions() const = 0;
 };
 
 } /* namespace frontend */

--- a/js/src/frontend/Stencil.h
+++ b/js/src/frontend/Stencil.h
@@ -416,7 +416,7 @@ class ScriptStencil {
 
   // Store all atoms into `atoms`
   // `atoms` is the pointer to `this.natoms`-length array of `GCPtrAtom`.
-  virtual void initAtomMap(GCPtrAtom* atoms) const = 0;
+  virtual bool initAtomMap(JSContext* cx, GCPtrAtom* atoms) const = 0;
 
   // Store all resume offsets into `resumeOffsets`
   // `resumeOffsets.Length()` is `this.numResumeOffsets`.

--- a/js/src/frontend/moz.build
+++ b/js/src/frontend/moz.build
@@ -23,6 +23,7 @@ GeneratedFile('ReservedWordsGenerated.h', script='GenerateReservedWords.py',
 
 UNIFIED_SOURCES += [
     'AbstractScope.cpp',
+    'BCEScriptStencil.cpp',
     'BytecodeCompiler.cpp',
     'BytecodeControlStructures.cpp',
     'BytecodeEmitter.cpp',

--- a/js/src/vm/JSScript.cpp
+++ b/js/src/vm/JSScript.cpp
@@ -4265,9 +4265,11 @@ PrivateScriptData* PrivateScriptData::new_(JSContext* cx, uint32_t ngcthings) {
   return new (raw) PrivateScriptData(ngcthings);
 }
 
-/* static */ bool PrivateScriptData::InitFromEmitter(
-    JSContext* cx, js::HandleScript script, frontend::BytecodeEmitter* bce) {
-  uint32_t ngcthings = bce->perScriptData().gcThingList().length();
+/* static */
+bool PrivateScriptData::InitFromStencil(
+    JSContext* cx, js::HandleScript script,
+    const frontend::ScriptStencil& stencil) {
+  uint32_t ngcthings = stencil.ngcthings;
 
   // Create and initialize PrivateScriptData
   if (!JSScript::createPrivateScriptData(cx, script, ngcthings)) {
@@ -4276,8 +4278,7 @@ PrivateScriptData* PrivateScriptData::new_(JSContext* cx, uint32_t ngcthings) {
 
   js::PrivateScriptData* data = script->data_;
   if (ngcthings) {
-    if (!bce->perScriptData().gcThingList().finish(cx, bce->parseInfo,
-                                                   data->gcthings())) {
+    if (!stencil.finishGCThings(cx, data->gcthings())) {
       return false;
     }
   }
@@ -4429,39 +4430,6 @@ bool JSScript::createPrivateScriptData(JSContext* cx, HandleScript script,
   return true;
 }
 
-static void InitAtomMap(frontend::AtomIndexMap& indices, GCPtrAtom* atoms) {
-  for (frontend::AtomIndexMap::Range r = indices.all(); !r.empty();
-       r.popFront()) {
-    JSAtom* atom = r.front().key();
-    uint32_t index = r.front().value();
-    MOZ_ASSERT(index < indices.count());
-    atoms[index].init(atom);
-  }
-}
-
-static bool NeedsFunctionEnvironmentObjects(frontend::BytecodeEmitter* bce) {
-  // See JSFunction::needsCallObject()
-  js::AbstractScope bodyScope = bce->bodyScope();
-  if (bodyScope.kind() == js::ScopeKind::Function) {
-    if (bodyScope.hasEnvironment()) {
-      return true;
-    }
-  }
-
-  // See JSScript::maybeNamedLambdaScope()
-  js::AbstractScope outerScope = bce->outermostScope();
-  if (outerScope.kind() == js::ScopeKind::NamedLambda ||
-      outerScope.kind() == js::ScopeKind::StrictNamedLambda) {
-    MOZ_ASSERT(bce->sc->asFunctionBox()->isNamedLambda());
-
-    if (outerScope.hasEnvironment()) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 void JSScript::initFromFunctionBox(frontend::FunctionBox* funbox) {
   setFlag(ImmutableFlags::FunHasExtensibleScope, funbox->hasExtensibleScope());
   setFlag(ImmutableFlags::NeedsHomeObject, funbox->needsHomeObject());
@@ -4489,8 +4457,8 @@ void JSScript::initFromFunctionBox(frontend::FunctionBox* funbox) {
 }
 
 /* static */
-bool JSScript::fullyInitFromEmitter(JSContext* cx, HandleScript script,
-                                    frontend::BytecodeEmitter* bce) {
+bool JSScript::fullyInitFromStencil(JSContext* cx, HandleScript script,
+                                    const frontend::ScriptStencil& stencil) {
   MOZ_ASSERT(!script->data_, "JSScript already initialized");
 
   // If initialization fails, we must call BaseScript::freeSharedData in order
@@ -4500,46 +4468,37 @@ bool JSScript::fullyInitFromEmitter(JSContext* cx, HandleScript script,
       mozilla::MakeScopeExit([&] { script->freeSharedData(); });
 
   /* The counts of indexed things must be checked during code generation. */
-  MOZ_ASSERT(bce->perScriptData().atomIndices()->count() <= INDEX_LIMIT);
-  MOZ_ASSERT(bce->perScriptData().gcThingList().length() <= INDEX_LIMIT);
-
-  uint64_t nslots =
-      bce->maxFixedSlots +
-      static_cast<uint64_t>(bce->bytecodeSection().maxStackDepth());
-  if (nslots > UINT32_MAX) {
-    bce->reportError(nullptr, JSMSG_NEED_DIET, js_script_str);
-    return false;
-  }
-
-  MOZ_ASSERT(script->lineno_ == bce->firstLine);
-  MOZ_ASSERT(script->column_ == bce->firstColumn);
+  MOZ_ASSERT(stencil.natoms <= INDEX_LIMIT);
+  MOZ_ASSERT(stencil.ngcthings <= INDEX_LIMIT);
+  MOZ_ASSERT(script->lineno_ == stencil.lineno);
+  MOZ_ASSERT(script->column_ == stencil.column);
 
   // Initialize script flags from BytecodeEmitter
-  script->setFlag(ImmutableFlags::Strict, bce->sc->strict());
+  script->setFlag(ImmutableFlags::Strict, stencil.strict);
   script->setFlag(ImmutableFlags::BindingsAccessedDynamically,
-                  bce->sc->bindingsAccessedDynamically());
-  script->setFlag(ImmutableFlags::HasCallSiteObj, bce->sc->hasCallSiteObj());
-  script->setFlag(ImmutableFlags::IsForEval, bce->sc->isEvalContext());
-  script->setFlag(ImmutableFlags::IsModule, bce->sc->isModuleContext());
-  script->setFlag(ImmutableFlags::IsFunction, bce->sc->isFunctionBox());
+                  stencil.bindingsAccessedDynamically);
+  script->setFlag(ImmutableFlags::HasCallSiteObj, stencil.hasCallSiteObj);
+  script->setFlag(ImmutableFlags::IsForEval, stencil.isForEval);
+  script->setFlag(ImmutableFlags::IsModule, stencil.isModule);
+  script->setFlag(ImmutableFlags::IsFunction, stencil.isFunction);
   script->setFlag(ImmutableFlags::HasNonSyntacticScope,
-                  bce->outermostScope().hasOnChain(ScopeKind::NonSyntactic));
+                  stencil.hasNonSyntacticScope);
   script->setFlag(ImmutableFlags::NeedsFunctionEnvironmentObjects,
-                  NeedsFunctionEnvironmentObjects(bce));
-  script->setFlag(ImmutableFlags::HasModuleGoal, bce->sc->hasModuleGoal());
+                  stencil.needsFunctionEnvironmentObjects);
+  script->setFlag(ImmutableFlags::HasModuleGoal, stencil.hasModuleGoal);
 
   // Initialize script flags from FunctionBox
-  if (bce->sc->isFunctionBox()) {
-    script->initFromFunctionBox(bce->sc->asFunctionBox());
+  if (stencil.isFunction) {
+    script->initFromFunctionBox(stencil.functionBox);
   }
 
   // Create and initialize PrivateScriptData
-  if (!PrivateScriptData::InitFromEmitter(cx, script, bce)) {
+  if (!PrivateScriptData::InitFromStencil(cx, script, stencil)) {
     return false;
   }
 
   // Create and initialize RuntimeScriptData/ImmutableScriptData
-  if (!RuntimeScriptData::InitFromEmitter(cx, script, bce, nslots)) {
+  if (!RuntimeScriptData::InitFromStencil(cx, script, stencil)) {
     return false;
   }
   if (!script->shareScriptData(cx)) {
@@ -4549,8 +4508,8 @@ bool JSScript::fullyInitFromEmitter(JSContext* cx, HandleScript script,
   // NOTE: JSScript is now constructed and should be linked in.
 
   // Link JSFunction to this JSScript.
-  if (bce->sc->isFunctionBox()) {
-    JSFunction* fun = bce->sc->asFunctionBox()->function();
+  if (stencil.isFunction) {
+    JSFunction* fun = stencil.functionBox->function();
     if (fun->isInterpretedLazy()) {
       fun->setUnlazifiedScript(script);
     } else {
@@ -4562,7 +4521,7 @@ bool JSScript::fullyInitFromEmitter(JSContext* cx, HandleScript script,
   // Part of the parse result – the scope containing each inner function – must
   // be stored in the inner function itself. Do this now that compilation is
   // complete and can no longer fail.
-  bce->perScriptData().gcThingList().finishInnerFunctions();
+  stencil.finishInnerFunctions();
 
 #ifdef JS_STRUCTURED_SPEW
   // We want this to happen after line number initialization to allow filtering
@@ -5206,25 +5165,25 @@ JSScript* js::CloneScriptIntoFunction(
   return dst;
 }
 
-/* static */ bool ImmutableScriptData::InitFromEmitter(
-    JSContext* cx, js::HandleScript script, frontend::BytecodeEmitter* bce,
-    uint32_t nslots) {
-  size_t codeLength = bce->bytecodeSection().code().length();
+/* static */
+bool ImmutableScriptData::InitFromStencil(
+    JSContext* cx, js::HandleScript script,
+    const frontend::ScriptStencil& stencil) {
+  size_t codeLength = stencil.code.Length();
   MOZ_RELEASE_ASSERT(codeLength <= frontend::MaxBytecodeLength);
 
   // There are 1-4 copies of SN_MAKE_TERMINATOR appended after the source
   // notes. These are a combination of sentinel and padding values.
   static_assert(frontend::MaxSrcNotesLength <= UINT32_MAX - CodeNoteAlign,
                 "Length + CodeNoteAlign shouldn't overflow UINT32_MAX");
-  size_t noteLength = bce->bytecodeSection().notes().length();
+  size_t noteLength = stencil.notes.Length();
   MOZ_RELEASE_ASSERT(noteLength <= frontend::MaxSrcNotesLength);
 
   size_t nullLength = ComputeNotePadding(codeLength, noteLength);
 
-  uint32_t numResumeOffsets =
-      bce->bytecodeSection().resumeOffsetList().length();
-  uint32_t numScopeNotes = bce->bytecodeSection().scopeNoteList().length();
-  uint32_t numTryNotes = bce->bytecodeSection().tryNoteList().length();
+  uint32_t numResumeOffsets = stencil.numResumeOffsets;
+  uint32_t numScopeNotes = stencil.numScopeNotes;
+  uint32_t numTryNotes = stencil.numTryNotes;
 
   // Allocate ImmutableScriptData
   if (!script->createImmutableScriptData(
@@ -5235,47 +5194,44 @@ JSScript* js::CloneScriptIntoFunction(
   js::ImmutableScriptData* data = script->immutableScriptData();
 
   // Initialize POD fields
-  data->mainOffset = bce->mainOffset();
-  data->nfixed = bce->maxFixedSlots;
-  data->nslots = nslots;
-  data->bodyScopeIndex = bce->bodyScopeIndex;
-  data->numICEntries = bce->bytecodeSection().numICEntries();
-  data->numBytecodeTypeSets =
-      std::min<uint32_t>(uint32_t(JSScript::MaxBytecodeTypeSets),
-                         bce->bytecodeSection().numTypeSets());
+  data->mainOffset = stencil.mainOffset;
+  data->nfixed = stencil.nfixed;
+  data->nslots = stencil.nslots;
+  data->bodyScopeIndex = stencil.bodyScopeIndex;
+  data->numICEntries = stencil.numICEntries;
+  data->numBytecodeTypeSets = std::min<uint32_t>(
+      uint32_t(JSScript::MaxBytecodeTypeSets), stencil.numBytecodeTypeSets);
 
-  if (bce->sc->isFunctionBox()) {
-    data->funLength = bce->sc->asFunctionBox()->length;
+  if (stencil.isFunction) {
+    data->funLength = stencil.functionBox->length;
   }
 
   // Initialize trailing arrays
-  std::copy_n(bce->bytecodeSection().code().begin(), codeLength, data->code());
-  std::copy_n(bce->bytecodeSection().notes().begin(), noteLength,
-              data->notes());
+  std::copy_n(stencil.code.data(), codeLength, data->code());
+  std::copy_n(stencil.notes.data(), noteLength, data->notes());
   std::fill_n(data->notes() + noteLength, nullLength, SRC_NULL);
 
-  bce->bytecodeSection().resumeOffsetList().finish(data->resumeOffsets());
-  bce->bytecodeSection().scopeNoteList().finish(data->scopeNotes());
-  bce->bytecodeSection().tryNoteList().finish(data->tryNotes());
+  stencil.finishResumeOffsets(data->resumeOffsets());
+  stencil.finishScopeNotes(data->scopeNotes());
+  stencil.finishTryNotes(data->tryNotes());
 
   return true;
 }
 
-/* static */ bool RuntimeScriptData::InitFromEmitter(
-    JSContext* cx, js::HandleScript script, frontend::BytecodeEmitter* bce,
-    uint32_t nslots) {
-  uint32_t natoms = bce->perScriptData().atomIndices()->count();
-
+/* static */
+bool RuntimeScriptData::InitFromStencil(
+    JSContext* cx, js::HandleScript script,
+    const frontend::ScriptStencil& stencil) {
   // Allocate RuntimeScriptData
-  if (!script->createScriptData(cx, natoms)) {
+  if (!script->createScriptData(cx, stencil.natoms)) {
     return false;
   }
   js::RuntimeScriptData* data = script->sharedData();
 
   // Initialize trailing arrays
-  InitAtomMap(*bce->perScriptData().atomIndices(), data->atoms());
+  stencil.initAtomMap(data->atoms());
 
-  return ImmutableScriptData::InitFromEmitter(cx, script, bce, nslots);
+  return ImmutableScriptData::InitFromStencil(cx, script, stencil);
 }
 
 void RuntimeScriptData::traceChildren(JSTracer* trc) {

--- a/js/src/vm/JSScript.cpp
+++ b/js/src/vm/JSScript.cpp
@@ -5229,7 +5229,9 @@ bool RuntimeScriptData::InitFromStencil(
   js::RuntimeScriptData* data = script->sharedData();
 
   // Initialize trailing arrays
-  stencil.initAtomMap(data->atoms());
+  if (!stencil.initAtomMap(cx, data->atoms())) {
+    return false;
+  }
 
   return ImmutableScriptData::InitFromStencil(cx, script, stencil);
 }

--- a/js/src/vm/JSScript.h
+++ b/js/src/vm/JSScript.h
@@ -81,7 +81,6 @@ namespace frontend {
 class FunctionBox;
 class ModuleSharedContext;
 class ScriptStencil;
-class Jsparagus;
 }  // namespace frontend
 
 namespace gc {
@@ -1683,7 +1682,6 @@ class alignas(uint32_t) ImmutableScriptData final {
                 "Structure packing is broken");
 
   friend class ::JSScript;
-  friend class ::js::frontend::Jsparagus;
 
  private:
   // Offsets (in bytes) from 'this' to each component array. The delta between
@@ -2617,8 +2615,6 @@ class JSScript : public js::BaseScript {
       JSContext* cx, js::HandleScript src, js::HandleObject functionOrGlobal,
       js::HandleScriptSourceObject sourceObject,
       js::MutableHandle<JS::GCVector<js::Scope*>> scopes);
-
-  friend class js::frontend::Jsparagus;
 
  private:
   using js::BaseScript::BaseScript;

--- a/js/src/vm/JSScript.h
+++ b/js/src/vm/JSScript.h
@@ -78,9 +78,9 @@ class DebugAPI;
 class DebugScript;
 
 namespace frontend {
-struct BytecodeEmitter;
 class FunctionBox;
 class ModuleSharedContext;
+class ScriptStencil;
 class Jsparagus;
 }  // namespace frontend
 
@@ -1573,8 +1573,8 @@ class alignas(uintptr_t) PrivateScriptData final {
   static bool Clone(JSContext* cx, js::HandleScript src, js::HandleScript dst,
                     js::MutableHandle<JS::GCVector<js::Scope*>> scopes);
 
-  static bool InitFromEmitter(JSContext* cx, js::HandleScript script,
-                              js::frontend::BytecodeEmitter* bce);
+  static bool InitFromStencil(JSContext* cx, js::HandleScript script,
+                              const js::frontend::ScriptStencil& stencil);
 
   void trace(JSTracer* trc);
 
@@ -1834,9 +1834,8 @@ class alignas(uint32_t) ImmutableScriptData final {
   static MOZ_MUST_USE XDRResult XDR(js::XDRState<mode>* xdr,
                                     js::HandleScript script);
 
-  static bool InitFromEmitter(JSContext* cx, js::HandleScript script,
-                              js::frontend::BytecodeEmitter* bce,
-                              uint32_t nslots);
+  static bool InitFromStencil(JSContext* cx, js::HandleScript script,
+                              const js::frontend::ScriptStencil& stencil);
 
   // ImmutableScriptData has trailing data so isn't copyable or movable.
   ImmutableScriptData(const ImmutableScriptData&) = delete;
@@ -1919,9 +1918,8 @@ class RuntimeScriptData final {
   // Mark this RuntimeScriptData for use in a new zone.
   void markForCrossZone(JSContext* cx);
 
-  static bool InitFromEmitter(JSContext* cx, js::HandleScript script,
-                              js::frontend::BytecodeEmitter* bce,
-                              uint32_t nslots);
+  static bool InitFromStencil(JSContext* cx, js::HandleScript script,
+                              const js::frontend::ScriptStencil& stencil);
 
   size_t sizeOfIncludingThis(mozilla::MallocSizeOf mallocSizeOf) {
     return mallocSizeOf(this) + mallocSizeOf(isd_.get());
@@ -2593,13 +2591,13 @@ class JSScript : public js::BaseScript {
   friend js::XDRResult js::ImmutableScriptData::XDR(js::XDRState<mode>* xdr,
                                                     js::HandleScript script);
 
-  friend bool js::RuntimeScriptData::InitFromEmitter(
+  friend bool js::RuntimeScriptData::InitFromStencil(
       JSContext* cx, js::HandleScript script,
-      js::frontend::BytecodeEmitter* bce, uint32_t nslot);
+      const js::frontend::ScriptStencil& stencil);
 
-  friend bool js::ImmutableScriptData::InitFromEmitter(
+  friend bool js::ImmutableScriptData::InitFromStencil(
       JSContext* cx, js::HandleScript script,
-      js::frontend::BytecodeEmitter* bce, uint32_t nslot);
+      const js::frontend::ScriptStencil& stencil);
 
   template <js::XDRMode mode>
   friend js::XDRResult js::PrivateScriptData::XDR(
@@ -2611,9 +2609,9 @@ class JSScript : public js::BaseScript {
       JSContext* cx, js::HandleScript src, js::HandleScript dst,
       js::MutableHandle<JS::GCVector<js::Scope*>> scopes);
 
-  friend bool js::PrivateScriptData::InitFromEmitter(
+  friend bool js::PrivateScriptData::InitFromStencil(
       JSContext* cx, js::HandleScript script,
-      js::frontend::BytecodeEmitter* bce);
+      const js::frontend::ScriptStencil& stencil);
 
   friend JSScript* js::detail::CopyScript(
       JSContext* cx, js::HandleScript src, js::HandleObject functionOrGlobal,
@@ -2643,7 +2641,7 @@ class JSScript : public js::BaseScript {
                                   js::Handle<js::LazyScript*> lazy);
 
   // NOTE: If you use createPrivateScriptData directly instead of via
-  // fullyInitFromEmitter, you are responsible for notifying the debugger
+  // fullyInitFromStencil, you are responsible for notifying the debugger
   // after successfully creating the script.
   static bool createPrivateScriptData(JSContext* cx,
                                       JS::Handle<JSScript*> script,
@@ -2653,8 +2651,8 @@ class JSScript : public js::BaseScript {
   void initFromFunctionBox(js::frontend::FunctionBox* funbox);
 
  public:
-  static bool fullyInitFromEmitter(JSContext* cx, js::HandleScript script,
-                                   js::frontend::BytecodeEmitter* bce);
+  static bool fullyInitFromStencil(JSContext* cx, js::HandleScript script,
+                                   const js::frontend::ScriptStencil& stencil);
 
 #ifdef DEBUG
  private:
@@ -2689,7 +2687,7 @@ class JSScript : public js::BaseScript {
 
   bool isUncompleted() const {
     // code() becomes non-null only if this script is complete.
-    // See the comment in JSScript::fullyInitFromEmitter.
+    // See the comment in JSScript::fullyInitFromStencil.
     return !code();
   }
 


### PR DESCRIPTION
Fix for https://github.com/mozilla-spidermonkey/jsparagus/issues/86

The same thing is done in `JSScript::fullyInitFromEmitter`.
https://searchfox.org/mozilla-central/rev/aa684c0c76136be80af4c6e429bce81dea55c429/js/src/vm/JSScript.cpp#4578-4582