### PR TITLE
 Use ScriptStencil in Smoosh

### DIFF
--- a/js/src/frontend-rs/frontend-rs.h
+++ b/js/src/frontend-rs/frontend-rs.h
@@ -24,6 +24,8 @@ struct JsparagusResult {
   ///
   /// A function of `bytecode`. See `JOF_IC`.
   uint32_t num_ic_entries;
+  /// Number of instructions in this script that have JOF_TYPESET.
+  uint32_t num_type_sets;
 };
 
 struct JsparagusCompileOptions {

--- a/js/src/frontend-rs/src/lib.rs
+++ b/js/src/frontend-rs/src/lib.rs
@@ -59,6 +59,9 @@ pub struct JsparagusResult {
     ///
     /// A function of `bytecode`. See `JOF_IC`.
     num_ic_entries: u32,
+
+    /// Number of instructions in this script that have JOF_TYPESET.
+    num_type_sets: u32,
 }
 
 enum JsparagusError {
@@ -83,6 +86,7 @@ pub unsafe extern "C" fn run_jsparagus(text: *const u8, text_len: usize, options
             ),
             maximum_stack_depth: result.maximum_stack_depth,
             num_ic_entries: result.num_ic_entries,
+            num_type_sets: result.num_type_sets,
         },
         Err(JsparagusError::GenericError(message)) => JsparagusResult {
             unimplemented: false,
@@ -91,6 +95,7 @@ pub unsafe extern "C" fn run_jsparagus(text: *const u8, text_len: usize, options
             strings: CVec::empty(),
             maximum_stack_depth: 0,
             num_ic_entries: 0,
+            num_type_sets: 0,
         },
         Err(JsparagusError::NotImplemented) => JsparagusResult {
             unimplemented: true,
@@ -99,6 +104,7 @@ pub unsafe extern "C" fn run_jsparagus(text: *const u8, text_len: usize, options
             strings: CVec::empty(),
             maximum_stack_depth: 0,
             num_ic_entries: 0,
+            num_type_sets: 0,
         },
     }
 }

--- a/js/src/frontend/BCEScriptStencil.cpp
+++ b/js/src/frontend/BCEScriptStencil.cpp
@@ -85,7 +85,7 @@ bool BCEScriptStencil::finishGCThings(
                                                    gcthings);
 }
 
-void BCEScriptStencil::initAtomMap(GCPtrAtom* atoms) const {
+bool BCEScriptStencil::initAtomMap(JSContext* cx, GCPtrAtom* atoms) const {
   const AtomIndexMap& indices = *bce_.perScriptData().atomIndices();
 
   for (AtomIndexMap::Range r = indices.all(); !r.empty(); r.popFront()) {
@@ -94,6 +94,7 @@ void BCEScriptStencil::initAtomMap(GCPtrAtom* atoms) const {
     MOZ_ASSERT(index < indices.count());
     atoms[index].init(atom);
   }
+  return true;
 }
 
 void BCEScriptStencil::finishResumeOffsets(

--- a/js/src/frontend/BCEScriptStencil.h
+++ b/js/src/frontend/BCEScriptStencil.h
@@ -35,7 +35,7 @@ class BCEScriptStencil : public ScriptStencil {
 
   virtual bool finishGCThings(JSContext* cx,
                               mozilla::Span<JS::GCCellPtr> gcthings) const;
-  virtual void initAtomMap(GCPtrAtom* atoms) const;
+  virtual bool initAtomMap(JSContext* cx, GCPtrAtom* atoms) const;
   virtual void finishResumeOffsets(mozilla::Span<uint32_t> resumeOffsets) const;
   virtual void finishScopeNotes(mozilla::Span<ScopeNote> scopeNotes) const;
   virtual void finishTryNotes(mozilla::Span<JSTryNote> tryNotes) const;

--- a/js/src/frontend/Frontend2.cpp
+++ b/js/src/frontend/Frontend2.cpp
@@ -6,8 +6,7 @@
 
 #include "frontend/Frontend2.h"
 
-#include "mozilla/ScopeExit.h"
-#include "mozilla/Span.h"  // mozilla::Span
+#include "mozilla/Span.h"  // mozilla::{Span, MakeSpan}
 
 #include <stddef.h>  // size_t
 #include <stdint.h>  // uint8_t, uint32_t
@@ -20,9 +19,9 @@
 #include "gc/Rooting.h"                    // RootedScriptSourceObject
 #include "js/HeapAPI.h"                    // JS::GCCellPtr
 #include "js/RootingAPI.h"                 // JS::Handle
-#include "js/TypeDecls.h"  // Rooted{Script,Value,String,Object}, jsbytecode
-#include "vm/JSAtom.h"     // AtomizeUTF8Chars
-#include "vm/JSScript.h"   // JSScript
+#include "js/TypeDecls.h"                  // Rooted{Script,Value,String,Object}
+#include "vm/JSAtom.h"                     // AtomizeUTF8Chars
+#include "vm/JSScript.h"                   // JSScript
 
 #include "vm/JSContext-inl.h"  // AutoKeepAtoms (used by BytecodeCompiler)
 
@@ -32,71 +31,80 @@ using namespace js::gc;
 using namespace js::frontend;
 using namespace js;
 
-// https://stackoverflow.com/questions/3407012/c-rounding-up-to-the-nearest-multiple-of-a-number
-int roundUp(int numToRound, int multiple) {
-  // assert(multiple && ((multiple & (multiple - 1)) == 0));
-  return (numToRound + multiple - 1) & -multiple;
-}
-
 namespace js {
 
 namespace frontend {
 
-/* static */
-bool Jsparagus::initScript(JSContext* cx, JS::Handle<JSScript*> script,
-                           const JsparagusResult& jsparagus) {
-  uint32_t numGCThings = 1;
-  if (!JSScript::createPrivateScriptData(cx, script, numGCThings)) {
-    return false;
+class SmooshScriptStencil : public ScriptStencil {
+  const JsparagusResult& jsparagus_;
+
+  void init() {
+    lineno = 1;
+    column = 0;
+
+    natoms = jsparagus_.strings.len;
+
+    ngcthings = 1;
+
+    numResumeOffsets = 0;
+    numScopeNotes = 0;
+    numTryNotes = 0;
+
+    mainOffset = 0;
+    nfixed = 0;
+    nslots = nfixed + jsparagus_.maximum_stack_depth;
+    bodyScopeIndex = 0;
+    numICEntries = jsparagus_.num_ic_entries;
+    numBytecodeTypeSets = 0;
+
+    strict = false;
+    bindingsAccessedDynamically = false;
+    hasCallSiteObj = false;
+    isForEval = false;
+    isModule = false;
+    isFunction = false;
+    hasNonSyntacticScope = false;
+    needsFunctionEnvironmentObjects = false;
+    hasModuleGoal = false;
+
+    code = mozilla::MakeSpan(jsparagus_.bytecode.data, jsparagus_.bytecode.len);
+    MOZ_ASSERT(notes.IsEmpty());
   }
 
-  mozilla::Span<JS::GCCellPtr> gcthings = script->data_->gcthings();
-  gcthings[0] = JS::GCCellPtr(&cx->global()->emptyGlobalScope());
-
-  uint32_t natoms = jsparagus.strings.len;
-  if (!script->createScriptData(cx, natoms)) {
-    return false;
-  }
-  for (uint32_t i = 0; i < natoms; i++) {
-    const CVec<uint8_t>& string = jsparagus.strings.data[i];
-    script->getAtom(i) =
-        AtomizeUTF8Chars(cx, (const char*)string.data, string.len);
+ public:
+  explicit SmooshScriptStencil(const JsparagusResult& jsparagus)
+      : jsparagus_(jsparagus) {
+    init();
   }
 
-  uint32_t codeLength = jsparagus.bytecode.len;
-
-  // We only want one byte of notes, but JSScript::createImmutableScriptData
-  // requires us to pad them to fill the space before the next (32-bit-aligned)
-  // field. See the layout comment on class ImmutableScriptData.
-  uint32_t noteLength =
-      roundUp(sizeof(ImmutableScriptData::Flags) + jsparagus.bytecode.len + 1,
-              4) -
-      (sizeof(ImmutableScriptData::Flags) + jsparagus.bytecode.len);
-
-  uint32_t numResumeOffsets = 0;
-  uint32_t numScopeNotes = 0;
-  uint32_t numTryNotes = 0;
-  if (!script->createImmutableScriptData(cx, codeLength, noteLength,
-                                         numResumeOffsets, numScopeNotes,
-                                         numTryNotes)) {
-    return false;
+  virtual bool finishGCThings(JSContext* cx,
+                              mozilla::Span<JS::GCCellPtr> gcthings) const {
+    gcthings[0] = JS::GCCellPtr(&cx->global()->emptyGlobalScope());
+    return true;
   }
-  js::ImmutableScriptData* data = script->immutableScriptData();
 
-  // Initialize POD fields
-  data->mainOffset = 0;
-  data->nfixed = 0;
-  data->nslots = data->nfixed + jsparagus.maximum_stack_depth;
-  data->bodyScopeIndex = 0;
-  data->numICEntries = jsparagus.num_ic_entries;
-  data->numBytecodeTypeSets = 0;
+  virtual bool initAtomMap(JSContext* cx, GCPtrAtom* atoms) const {
+    for (uint32_t i = 0; i < natoms; i++) {
+      const CVec<uint8_t>& string = jsparagus_.strings.data[i];
+      JSAtom* atom = AtomizeUTF8Chars(cx, (const char*)string.data, string.len);
+      if (!atom) {
+        return false;
+      }
+      atoms[i] = atom;
+    }
 
-  // Initialize trailing arrays
-  std::copy_n(jsparagus.bytecode.data, codeLength, data->code());
-  std::fill_n(data->notes(), noteLength, SRC_NULL);
+    return true;
+  }
 
-  return script->shareScriptData(cx);
-}
+  virtual void finishResumeOffsets(
+      mozilla::Span<uint32_t> resumeOffsets) const {}
+
+  virtual void finishScopeNotes(mozilla::Span<ScopeNote> scopeNotes) const {}
+
+  virtual void finishTryNotes(mozilla::Span<JSTryNote> tryNotes) const {}
+
+  virtual void finishInnerFunctions() const {}
+};
 
 // Free given JsparagusResult on leaving scope.
 class AutoFreeJsparagusResult {
@@ -161,7 +169,8 @@ JSScript* Jsparagus::compileGlobalScript(CompilationInfo& compilationInfo,
 
   *unimplemented = false;
 
-  RootedScriptSourceObject sso(cx, frontend::CreateScriptSourceObject(cx, options));
+  RootedScriptSourceObject sso(cx,
+                               frontend::CreateScriptSourceObject(cx, options));
   if (!sso) {
     return nullptr;
   }
@@ -172,10 +181,11 @@ JSScript* Jsparagus::compileGlobalScript(CompilationInfo& compilationInfo,
     return nullptr;
   }
 
-  RootedScript script(cx, JSScript::Create(cx, cx->global(), options,
-                                           sso, 0, length, 0, length, 1, 0));
+  RootedScript script(cx, JSScript::Create(cx, cx->global(), options, sso, 0,
+                                           length, 0, length, 1, 0));
 
-  if (!initScript(cx, script, jsparagus)) {
+  SmooshScriptStencil stencil(jsparagus);
+  if (!JSScript::fullyInitFromStencil(cx, script, stencil)) {
     return nullptr;
   }
 

--- a/js/src/frontend/Frontend2.cpp
+++ b/js/src/frontend/Frontend2.cpp
@@ -55,7 +55,7 @@ class SmooshScriptStencil : public ScriptStencil {
     nslots = nfixed + jsparagus_.maximum_stack_depth;
     bodyScopeIndex = 0;
     numICEntries = jsparagus_.num_ic_entries;
-    numBytecodeTypeSets = 0;
+    numBytecodeTypeSets = jsparagus_.num_type_sets;
 
     strict = false;
     bindingsAccessedDynamically = false;

--- a/js/src/frontend/Frontend2.h
+++ b/js/src/frontend/Frontend2.h
@@ -31,9 +31,6 @@ class GlobalScriptInfo;
 // This is declarated as a class mostly to solve dependency around `friend`
 // declarations in the simple way.
 class Jsparagus {
-  static bool initScript(JSContext* cx, JS::Handle<JSScript*> script,
-                         const JsparagusResult& jsparagus);
-
  public:
   static JSScript* compileGlobalScript(
       CompilationInfo& compilationInfo, JS::SourceText<mozilla::Utf8Unit>& srcBuf,
@@ -42,8 +39,10 @@ class Jsparagus {
 
 // Use the Rust frontend to parse and free the generated AST. Returns true if no
 // error were detected while parsing.
-MOZ_MUST_USE bool RustParseScript(JSContext* cx, const uint8_t* bytes, size_t length);
-MOZ_MUST_USE bool RustParseModule(JSContext* cx, const uint8_t* bytes, size_t length);
+MOZ_MUST_USE bool RustParseScript(JSContext* cx, const uint8_t* bytes,
+                                  size_t length);
+MOZ_MUST_USE bool RustParseModule(JSContext* cx, const uint8_t* bytes,
+                                  size_t length);
 
 }  // namespace frontend
 

--- a/js/src/frontend/Stencil.h
+++ b/js/src/frontend/Stencil.h
@@ -419,7 +419,7 @@ class ScriptStencil {
 
   // Store all atoms into `atoms`
   // `atoms` is the pointer to `this.natoms`-length array of `GCPtrAtom`.
-  virtual void initAtomMap(GCPtrAtom* atoms) const = 0;
+  virtual bool initAtomMap(JSContext* cx, GCPtrAtom* atoms) const = 0;
 
   // Store all resume offsets into `resumeOffsets`
   // `resumeOffsets.Length()` is `this.numResumeOffsets`.

--- a/js/src/vm/JSScript.cpp
+++ b/js/src/vm/JSScript.cpp
@@ -5229,7 +5229,9 @@ bool RuntimeScriptData::InitFromStencil(
   js::RuntimeScriptData* data = script->sharedData();
 
   // Initialize trailing arrays
-  stencil.initAtomMap(data->atoms());
+  if (!stencil.initAtomMap(cx, data->atoms())) {
+    return false;
+  }
 
   return ImmutableScriptData::InitFromStencil(cx, script, stencil);
 }

--- a/js/src/vm/JSScript.h
+++ b/js/src/vm/JSScript.h
@@ -80,7 +80,6 @@ class DebugScript;
 namespace frontend {
 class FunctionBox;
 class ModuleSharedContext;
-class Jsparagus;
 class ScriptStencil;
 }  // namespace frontend
 
@@ -1683,7 +1682,6 @@ class alignas(uint32_t) ImmutableScriptData final {
                 "Structure packing is broken");
 
   friend class ::JSScript;
-  friend class ::js::frontend::Jsparagus;
 
  private:
   // Offsets (in bytes) from 'this' to each component array. The delta between
@@ -2617,8 +2615,6 @@ class JSScript : public js::BaseScript {
       JSContext* cx, js::HandleScript src, js::HandleObject functionOrGlobal,
       js::HandleScriptSourceObject sourceObject,
       js::MutableHandle<JS::GCVector<js::Scope*>> scopes);
-
-  friend class js::frontend::Jsparagus;
 
  private:
   using js::BaseScript::BaseScript;


### PR DESCRIPTION
fixes https://github.com/mozilla-spidermonkey/jsparagus/issues/86 and https://github.com/mozilla-spidermonkey/jsparagus/issues/192

the first one replaces `Jsparagus::initScript` with `SmooshScriptStencil`+ `JSScript::fullyInitFromStencil`.
the second one passes `num_type_sets` added by https://github.com/mozilla-spidermonkey/jsparagus/pull/197 to `SmooshScriptStencil`