### PR TITLE
[WIP] Add tracking byte

### DIFF
--- a/js/public/ContextOptions.h
+++ b/js/public/ContextOptions.h
@@ -39,6 +39,7 @@ class JS_PUBLIC_API ContextOptions {
         strictMode_(false),
         extraWarnings_(false),
 #ifdef JS_ENABLE_SMOOSH
+        trackNotImplemented_(false),
         trySmoosh_(false),
 #endif
         fuzzing_(false) {
@@ -182,6 +183,13 @@ class JS_PUBLIC_API ContextOptions {
   }
 
 #ifdef JS_ENABLE_SMOOSH
+  // Track Number of Not Implemented Calls by writing to a file
+  bool trackNotImplemented() const { return trackNotImplemented_; }
+  ContextOptions& setTrackNotImplemented(bool flag) {
+    trackNotImplemented_ = flag;
+    return *this;
+  }
+
   // Try compiling SmooshMonkey frontend first, and fallback to C++
   // implementation when it fails.
   bool trySmoosh() const { return trySmoosh_; }
@@ -189,6 +197,7 @@ class JS_PUBLIC_API ContextOptions {
     trySmoosh_ = flag;
     return *this;
   }
+
 #endif  // JS_ENABLE_SMOOSH
 
   bool fuzzing() const { return fuzzing_; }
@@ -225,6 +234,7 @@ class JS_PUBLIC_API ContextOptions {
   bool strictMode_ : 1;
   bool extraWarnings_ : 1;
 #ifdef JS_ENABLE_SMOOSH
+  bool trackNotImplemented_ : 1;
   bool trySmoosh_ : 1;
 #endif
   bool fuzzing_ : 1;

--- a/js/src/frontend/BytecodeCompiler.cpp
+++ b/js/src/frontend/BytecodeCompiler.cpp
@@ -226,12 +226,20 @@ JSScript* frontend::CompileGlobalScript(CompilationInfo& compilationInfo,
 #ifdef JS_ENABLE_SMOOSH
   if (compilationInfo.cx->options().trySmoosh()) {
     bool unimplemented = false;
+    JSContext* cx = compilationInfo.cx;
+    JSRuntime* rt = cx->runtime();
     auto script =
         Smoosh::compileGlobalScript(compilationInfo, srcBuf, &unimplemented);
     if (!unimplemented) {
+      if (compilationInfo.cx->options().trackNotImplemented()) {
+        rt->parserWatcherFile.put("1");
+      }
       return script;
     }
 
+    if (compilationInfo.cx->options().trackNotImplemented()) {
+      rt->parserWatcherFile.put("0");
+    }
     fprintf(stderr, "Falling back!\n");
   }
 #endif  // JS_ENABLE_SMOOSH

--- a/js/src/shell/js.cpp
+++ b/js/src/shell/js.cpp
@@ -10125,6 +10125,14 @@ static MOZ_MUST_USE bool ProcessArgs(JSContext* cx, OptionParser* op) {
   if (op->getBoolOption("smoosh")) {
     JS::ContextOptionsRef(cx).setTrySmoosh(true);
   }
+
+  if (const char* filename = op->getStringOption("not-implemented-watchfile")) {
+    FILE* out = fopen(filename, "a");
+    MOZ_RELEASE_ASSERT(out);
+    setbuf(out, nullptr);  // Make unbuffered
+    cx->runtime()->parserWatcherFile.init(out);
+    JS::ContextOptionsRef(cx).setTrackNotImplemented(true);
+  }
 #endif
 
   /* |scriptArgs| gets bound on the global before any code is run. */
@@ -11328,6 +11336,8 @@ int main(int argc, char** argv, char** envp) {
                         "Suppress crash minidumps") ||
 #ifdef JS_ENABLE_SMOOSH
       !op.addBoolOption('\0', "smoosh", "Use SmooshMonkey") ||
+      !op.addStringOption('\0', "not-implemented-watchfile", "[filename]",
+                          "Track NotImplemented errors in the new frontend") ||
 #else
       !op.addBoolOption('\0', "smoosh", "No-op") ||
 #endif

--- a/js/src/vm/Runtime.h
+++ b/js/src/vm/Runtime.h
@@ -288,6 +288,7 @@ struct JSRuntime {
  public:
   JSContext* mainContextFromAnyThread() const { return mainContext_; }
   const void* addressOfMainContext() { return &mainContext_; }
+  js::Fprinter parserWatcherFile;
 
   inline JSContext* mainContextFromOwnThread();
 


### PR DESCRIPTION
This builds on top of arai's work in https://github.com/mozilla-spidermonkey/rust-frontend/pull/40 -- in order to follow the work there around the configure options.

The patch itself is one commit, and introduces a new string option `--not-implemented-watchfile` which takes as an argument a file name. 

Do not merge this until Arai's is merged