### PR TITLE
Add MPL license comment (fixes #53)

### DIFF
--- a/js/src/frontend/smoosh/src/lib.rs
+++ b/js/src/frontend/smoosh/src/lib.rs
@@ -1,3 +1,20 @@
+/* Copyright  Mozilla Foundation
+ *
+ * Licensed under the Apache License (Version 2.0), or the MIT license,
+ * (the "Licenses") at your option. You may not use this file except in
+ * compliance with one of the Licenses. You may obtain copies of the
+ * Licenses at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *    http://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licenses is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licenses for the specific language governing permissions and
+ * limitations under the Licenses.
+ */
+
 extern crate parser;
 
 use ast::types::Program;


### PR DESCRIPTION
There are 2 groups of lib.rs inside js

has MPL comment
 * https://searchfox.org/mozilla-central/source/js/rust/src/lib.rs
 * https://searchfox.org/mozilla-central/source/js/src/lib.rs

has Apache License comment
 * https://searchfox.org/mozilla-central/source/js/src/rust/lib.rs
 * https://searchfox.org/mozilla-central/source/js/src/rust/shared/lib.rs
 * https://searchfox.org/mozilla-central/source/js/src/wasm/cranelift/src/lib.rs

not sure which one to use, but so far I've added MPL comment.
